### PR TITLE
Java8でユニットテストが実行出来ない問題に対応するために、JDKに応じたプロファイルを定義した。

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# nablarch-testing-jetty6 
+## テスト環境
+- Java SE 6/8 (※Java SE 11 以降には対応していない)

--- a/pom.xml
+++ b/pom.xml
@@ -25,12 +25,59 @@
     <ecj.version>3.5.1</ecj.version>
   </properties>
   
+  <profiles>
+    <!-- リリースビルド及びJava6テスト用プロファイル。-->
+    <profile>
+      <id>java6</id>
+      <activation>
+        <jdk>1.6</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.nablarch.framework</groupId>
+          <artifactId>nablarch-testing</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
+    <!-- Java7テスト用プロファイル。Java6と同様の依存関係を使用する-->
+    <profile>
+      <id>java7</id>
+      <activation>
+        <jdk>1.7</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.nablarch.framework</groupId>
+          <artifactId>nablarch-testing</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
+    <!-- Java8テスト用プロファイル。JSPのコンパイラを差し替える-->
+    <profile>
+      <id>java8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <properties>
+        <ecj.version>4.5.1</ecj.version>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>com.nablarch.framework</groupId>
+          <artifactId>nablarch-testing</artifactId>
+          <exclusions>
+            <exclusion>
+              <groupId>org.eclipse.jdt.core.compiler</groupId>
+              <artifactId>ecj</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+    <!-- 本モジュールはJava8までしかサポートしないため、これより新しいJDK用のプロファイルは存在しない-->
+  </profiles>
+
   <dependencies>
-    <dependency>
-      <groupId>com.nablarch.framework</groupId>
-      <artifactId>nablarch-testing</artifactId>
-    </dependency>
-    
     <dependency>
       <groupId>org.mortbay.jetty</groupId>
       <artifactId>jsp-2.1-glassfish</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,8 @@
   </properties>
   
   <profiles>
-    <!-- リリースビルド及びJava6テスト用プロファイル。-->
+    <!-- テストのためにJDKに応じた依存関係を設定する必要があるため、JDKに応じたプロファイルを定義。 -->
+    <!-- リリース用ビルドはJava6用プロファイルで行なう。-->
     <profile>
       <id>java6</id>
       <activation>
@@ -39,7 +40,6 @@
         </dependency>
       </dependencies>
     </profile>
-    <!-- Java7テスト用プロファイル。Java6と同様の依存関係を使用する-->
     <profile>
       <id>java7</id>
       <activation>
@@ -52,7 +52,6 @@
         </dependency>
       </dependencies>
     </profile>
-    <!-- Java8テスト用プロファイル。JSPのコンパイラを差し替える-->
     <profile>
       <id>java8</id>
       <activation>
@@ -74,7 +73,6 @@
         </dependency>
       </dependencies>
     </profile>
-    <!-- 本モジュールはJava8までしかサポートしないため、これより新しいJDK用のプロファイルは存在しない-->
   </profiles>
 
   <dependencies>


### PR DESCRIPTION
## 変更内容
- テストのためにJDKに応じた依存関係を設定する必要があるため、JDKに応じたプロファイルを定義した。  

## 補足事項
- ビルドされる成果物に影響はないため、本PRはリリース不要。  

