### PR TITLE
「デフォルトではボディが空の際にContent-Typeの自動設定を行なわないように修正」に伴う対応

### DIFF
--- a/src/test/java/nablarch/fw/web/HttpServerTest.java
+++ b/src/test/java/nablarch/fw/web/HttpServerTest.java
@@ -621,7 +621,7 @@ public class HttpServerTest {
         HttpResponse res = server.handle(req, ctx);
 
         assertEquals(200, res.getStatusCode());
-        assertNull(res.getContentType());
+        assertNull(res.getHeader("Content-Type"));
         assertEquals("/app/test.html", req.getRequestPath());
 
         File[] dumpFiles = dumpRoot.listFiles();
@@ -657,7 +657,7 @@ public class HttpServerTest {
     @Test
     public void testHttpMessageDumpBodyEmptyFacilitiesForResponseWithNoBodyEnabledTrue() throws Exception {
         final WebConfig webConfig = new WebConfig();
-        webConfig.setContentTypeForResponseWithNoBodyEnabled(true);
+        webConfig.setAddDefaultContentTypeForNoBodyResponse(true);
         SystemRepository.load(new ObjectLoader() {
             @Override
             public Map<String, Object> load() {
@@ -698,7 +698,7 @@ public class HttpServerTest {
         HttpResponse res = server.handle(req, ctx);
 
         assertEquals(200, res.getStatusCode());
-        assertEquals("text/plain;charset=UTF-8", res.getContentType());
+        assertEquals("text/plain;charset=UTF-8", res.getHeader("Content-Type"));
         assertEquals("/app/test.html", req.getRequestPath());
 
         File[] dumpFiles = dumpRoot.listFiles();

--- a/src/test/java/nablarch/fw/web/HttpServerTest.java
+++ b/src/test/java/nablarch/fw/web/HttpServerTest.java
@@ -621,7 +621,7 @@ public class HttpServerTest {
         HttpResponse res = server.handle(req, ctx);
 
         assertEquals(200, res.getStatusCode());
-        assertNull(res.getHeader("Content-Type"));
+        assertNull(res.getContentType());
         assertEquals("/app/test.html", req.getRequestPath());
 
         File[] dumpFiles = dumpRoot.listFiles();
@@ -698,7 +698,7 @@ public class HttpServerTest {
         HttpResponse res = server.handle(req, ctx);
 
         assertEquals(200, res.getStatusCode());
-        assertEquals("text/plain;charset=UTF-8", res.getHeader("Content-Type"));
+        assertEquals("text/plain;charset=UTF-8", res.getContentType());
         assertEquals("/app/test.html", req.getRequestPath());
 
         File[] dumpFiles = dumpRoot.listFiles();


### PR DESCRIPTION
## 背景
https://github.com/nablarch/nablarch-fw-web/pull/92 の対応に伴うテストコード修正です。

## やったこと
テストコードについて以下を修正しました。
* webConfigのプロパティ名変更対応

## 補足
テストコードの修正のみなので、リリース不要です。