### PR TITLE
モックサーバのレスポンスをnullから空のインスタンスに変更

### DIFF
--- a/src/test/java/nablarch/test/core/http/HttpRequestTestSupportTest.java
+++ b/src/test/java/nablarch/test/core/http/HttpRequestTestSupportTest.java
@@ -584,7 +584,7 @@ public class HttpRequestTestSupportTest {
          */
         @Override
         public HttpResponse handle(HttpRequest req, ExecutionContext unused) {
-            return null;
+            return new HttpResponse();
         }
 
         @Override


### PR DESCRIPTION
## 背景
https://github.com/nablarch/nablarch-testing/pull/36 の修正に伴うテストの修正。
本モジュールでテストしている`HttpRequestTestSupport`クラスに変更が入った。
https://github.com/nablarch/nablarch-testing/pull/36/files#diff-b4ea0182ff573b772186e7495b670ec36f5eb5ff5ca6d1ef5e091cb2ecc16d9bR282
上記変更により、NullPointerExceptionが発生するようになった。
原因はモックサーバがnullを返却しているため。
テストではサーバが返すレスポンスは関心事ではないためnullを返していた。

## 対応内容
モックサーバが返すレスポンスをデフォルトコンストラクタでインスタンス化したレスポンスに変更。

## 確認したこと
モジュールに含まれる全ユニットテストが成功すること

## 補足
このモジュールのリリースは不要(テストケース追加のみであるため)